### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,5 +1,7 @@
 ---
 name: Check
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -7,6 +9,9 @@ on:
 
 jobs:
   actionlint:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -45,6 +50,9 @@ jobs:
           start-url: 'http://localhost:1313'
 
   npm-audit:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/rotex1800/rotex1800/security/code-scanning/13](https://github.com/rotex1800/rotex1800/security/code-scanning/13)

To fix this issue, add an explicit `permissions:` block in the workflow file. The best-practice approach is to assign the least privilege required for each job. You can set permissions at the workflow root level, so they apply to all jobs unless overridden per job, or you can set the permissions for each job separately—for example, jobs which only need to read code set `contents: read`, jobs that need to write issues or PRs get those added as needed.  
A minimal starting point is to add `permissions: contents: read` at the workflow root, which will cover most jobs that do not require write access. For jobs needing additional permissions (like `reviewdog/action-actionlint` to report on PRs, or `npm-audit-action` to create issues), specify added permission blocks at the job level.  
Specifically:
- Add `permissions: contents: read` at the root/workflow level (after `name` and before `on`).
- Under `actionlint`, add `permissions: contents: read, pull-requests: write` if needed by `reviewdog` reporter.
- Under `npm-audit`, since it creates issues, add `permissions: contents: read, issues: write`.
- For `test-links`, likely only read access is needed, so it will inherit the root permission.

No imports or new dependencies are needed; these are YAML edits.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
