### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,6 @@
 name: Publish
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/rotex1800/rotex1800/security/code-scanning/1](https://github.com/rotex1800/rotex1800/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly grant the minimum level of access required for the steps in this job. Since the shown workflow does not check out code to commit or push changes, only reads repository content, and uploads an artifact/uses FTP, only `contents: read` is needed for the job. This block should be placed at the job (under `publish:`) or workflow root (top level, just after `name` and before `on`). Placing it at the workflow root applies to all jobs; for clarity and future-proofing, the workflow root is preferable here. No new imports or external packages are needed — just add the following block to the workflow YAML after `name`:

```yaml
permissions:
  contents: read
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
